### PR TITLE
Fix auth screen flicker: start hidden, show only when no session conf…

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@ var supabase=function(e){function t(e,t){var r={};for(var s in e)Object.prototyp
       position: fixed; inset: 0; z-index: 500;
       background: #f5f5f8;
       color: #16161e;
-      display: flex;
+      display: none;
       align-items: flex-start; justify-content: center;
       overflow-y: auto;
       padding: calc(1.75rem + env(safe-area-inset-top, 0px)) 1.25rem 2rem;

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 // WristLog — Service Worker
 // Enables "Add to Home Screen" (PWA) and offline fallback
 
-const CACHE = 'wristlog-v170';
+const CACHE = 'wristlog-v171';
 const PRECACHE = ['/', '/index.html', '/manifest.json', '/icon.svg', '/profile/', '/p/'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
…irmed

The auth-screen had display:flex in CSS, making it visible on every page load before getSession() could check for an existing session and hide it. Changed to display:none by default — the auth flow already sets it to display:flex in every code path where no session is found. Logged-in users now never see the landing page flash. Bumps SW cache to v171.

https://claude.ai/code/session_01XKWe5eAhs7Z7aj9RE75vnr